### PR TITLE
Add emissions and trees to the trade screen

### DIFF
--- a/mobile/TragedyOfTheCO2mmons/components/Status.tsx
+++ b/mobile/TragedyOfTheCO2mmons/components/Status.tsx
@@ -17,6 +17,7 @@ const Status = (props: StatusProps) => {
   const [balance, setBalance] = useState(0);
   const [CO2, setCO2] = useState(0);
   const [globalCO2, setGlobalCO2] = useState(0);
+  const [trees, setTrees] = useState(0);
   const [pending, setPending] = useState([]);
   const [refreshStatus, setRefreshStatus] = useState(false);
 
@@ -26,6 +27,7 @@ const Status = (props: StatusProps) => {
         setBalance(response.balance);
         setCO2(response.co2);
         setGlobalCO2(response.globalCO2);
+        setTrees(response.trees);
         setPending(response.pending);
       });
       setRefreshStatus(false);
@@ -56,6 +58,9 @@ const Status = (props: StatusProps) => {
         </Text>
         <Text style={styles.StatusText}>
           Current CO₂ levels:<Text style={styles.Bold}> {globalCO2} </Text>ppm
+        </Text>
+        <Text style={styles.StatusText}>
+          Trees planted:<Text style={styles.Bold}> {trees}</Text>
         </Text>
         {pending.length ? (
           <View style={styles.ButtonWrapper}>

--- a/mobile/TragedyOfTheCO2mmons/screens/Plant.tsx
+++ b/mobile/TragedyOfTheCO2mmons/screens/Plant.tsx
@@ -23,7 +23,7 @@ export const PlantScreen = () => {
         alert(
           `${trees} tree${
             trees === 1 ? "" : "s"
-          } planted! 🌳 Your new whatevzDAI balance: ${response.balance}`
+          } planted! 🌳\nYour new whatevzDAI balance: ${response.balance}`
         );
       } else {
         alert(`Couldn't plant 😔 ${response.error}`);

--- a/mobile/TragedyOfTheCO2mmons/screens/Trade.tsx
+++ b/mobile/TragedyOfTheCO2mmons/screens/Trade.tsx
@@ -5,19 +5,17 @@ import { getPlayerList, trade } from "../api";
 import { material } from "react-native-typography";
 import { NavigationScreenProps } from "react-navigation";
 
-export type Player = {
-  id: string;
+interface PlayerInfo {
   name: string;
   avatar: string;
-};
+  balance: number;
+  co2: number;
+  trees: number;
+}
 
-type PlayerInfo = {
-  name: string;
-  avatar: string;
-  balance: string;
-  co2: string;
-  trees: string;
-};
+export interface Player extends PlayerInfo {
+  id: string;
+}
 
 type TradeProps = {
   navigation: NavigationScreenProps["navigation"];
@@ -97,7 +95,9 @@ export const TradeScreen = (props: TradeProps) => {
           onPress={doTrade(item.id, item.name)}
         >
           <Text style={styles.Name}>{item.name}</Text>
-          <Text>CO₂: {item.co2}, trees: {item.trees}, balance: {item.balance}</Text>
+          <Text>
+            💰 {item.balance} 🌫️ {item.co2} 🌳 {item.trees}
+          </Text>
         </TouchableNativeFeedback>
       </View>
     </View>

--- a/mobile/TragedyOfTheCO2mmons/screens/Trade.tsx
+++ b/mobile/TragedyOfTheCO2mmons/screens/Trade.tsx
@@ -14,6 +14,9 @@ export type Player = {
 type PlayerInfo = {
   name: string;
   avatar: string;
+  balance: string;
+  co2: string;
+  trees: string;
 };
 
 type TradeProps = {
@@ -41,7 +44,10 @@ export const TradeScreen = (props: TradeProps) => {
             .map<Player>(([id, player]) => ({
               id,
               name: player.name,
-              avatar: player.avatar
+              avatar: player.avatar,
+              balance: player.balance,
+              co2: player.co2,
+              trees: player.trees
             }))
             .sort((p1, p2) => {
               const n1 = p1.name.toLowerCase();
@@ -91,6 +97,7 @@ export const TradeScreen = (props: TradeProps) => {
           onPress={doTrade(item.id, item.name)}
         >
           <Text style={styles.Name}>{item.name}</Text>
+          <Text>CO₂: {item.co2}, trees: {item.trees}, balance: {item.balance}</Text>
         </TouchableNativeFeedback>
       </View>
     </View>


### PR DESCRIPTION
When the CO₂ level is high, I find difficult to decide with whom to trade. Adding the CO₂ emissions of a player would help me in the decision.

We can test the game with and without and see how people react to this.